### PR TITLE
Add rest of string32 UT

### DIFF
--- a/UTD/src/data-structures/string32.cpp
+++ b/UTD/src/data-structures/string32.cpp
@@ -23,275 +23,270 @@ static constexpr size_t CHAR_BUFFER_SIZE{ 7 };
 // Private Methods
 
 bool utd::string32::isLargeString() const {
-        return _flags.isLargeString;
+  return _flags.isLargeString;
 }
 
 void utd::string32::setLargeString() {
-        _flags.isLargeString = true;
+  _flags.isLargeString = true;
 }
 
 /*
 * For small strings, _capacity, _char_buffer and _flags are used to store the character data and null terminator
 */
 void utd::string32::pointToInSituMemory() {
-        _data = (char*) &_capacity;
+  _data = (char*) &_capacity;
 }
 
 
 // Constructors
 
 utd::string32::string32() {
-        // TODO: can we improve this by using a global variable for the empty string?
-        _size     = 0;
-        _capacity = 0;
-        pointToInSituMemory();
+  // TODO: can we improve this by using a global variable for the empty string?
+  _size     = 0;
+  _capacity = 0;
+  pointToInSituMemory();
 }
 
 utd::string32::string32(const char* s) {
-        _size = strlen(s);
-        if (_size > SMALL_STRING_MAX_LENGTH) {
-          _capacity = _size + 1;
-          _data     = new char[_capacity];
-          setLargeString();
-        } else {
-          pointToInSituMemory();
-        }
-        strcpy(_data, s);
+  _size = strlen(s);
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    _capacity = _size + 1;
+    _data     = new char[_capacity];
+    setLargeString();
+  } else {
+    pointToInSituMemory();
+  }
+  strcpy(_data, s);
 }
 
 utd::string32::string32(const string32& s) {
-        _size     = s._size;
-        _capacity = s._capacity;
-        memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
-        _flags = s._flags;
-        if (_size > SMALL_STRING_MAX_LENGTH) {
-          _data = new char[_capacity];
-          strcpy(_data, s._data);
-        } else {
-          pointToInSituMemory();
-        }
+  _size     = s._size;
+  _capacity = s._capacity;
+  memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
+  _flags = s._flags;
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    _data = new char[_capacity];
+    strcpy(_data, s._data);
+  } else {
+    pointToInSituMemory();
+  }
 }
 
 utd::string32::string32(string32&& s) noexcept {
-        _size     = s._size;
-        _capacity = s._capacity;
-        memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
-        _flags = s._flags;
+  _size     = s._size;
+  _capacity = s._capacity;
+  memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
+  _flags = s._flags;
 
-        if (_size > SMALL_STRING_MAX_LENGTH) {
-          _data = s._data;
-        } else {
-          pointToInSituMemory();
-        }
-        
-        s._data     = nullptr;
-        s._size     = 0;
-        s._capacity = 0;
-        memset(s._char_buffer, 0, CHAR_BUFFER_SIZE);
-        s._flags.reset();
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    _data = s._data;
+  } else {
+    pointToInSituMemory();
+  }
+  
+  s._data     = nullptr;
+  s._size     = 0;
+  s._capacity = 0;
+  memset(s._char_buffer, 0, CHAR_BUFFER_SIZE);
+  s._flags.reset();
 }
 
 utd::string32& utd::string32::operator=(const string32& s) {
-    if (_size > SMALL_STRING_MAX_LENGTH) {
-        delete[] _data;
-    }
-    _size     = s._size;
-    _capacity = s._capacity;
-    memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
-    _flags = s._flags;
-
-	if (_size > SMALL_STRING_MAX_LENGTH) {
-        _data = new char[_capacity];
-        strcpy(_data, s._data);
-    } else {
-        pointToInSituMemory();
-    }
-    return *this;
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    delete[] _data;
+  }
+  _size     = s._size;
+  _capacity = s._capacity;
+  memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
+  _flags = s._flags;
+  
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    _data = new char[_capacity];
+    strcpy(_data, s._data);
+  } else {
+    pointToInSituMemory();
+  }
+  return *this;
 }
 
 utd::string32& utd::string32::operator=(string32&& s) noexcept {
-    if (_size > SMALL_STRING_MAX_LENGTH) {
-        delete[] _data;
-    }
-    _size     = s._size;
-    _capacity = s._capacity;
-    memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
-    _flags = s._flags;
-    
-    if (_size > SMALL_STRING_MAX_LENGTH) {
-        _data = s._data;
-    } else {
-        pointToInSituMemory();
-    }
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    delete[] _data;
+  }
+  _size     = s._size;
+  _capacity = s._capacity;
+  memcpy(_char_buffer, s._char_buffer, CHAR_BUFFER_SIZE);
+  _flags = s._flags;
 
-    s._data = nullptr;
-    s._size = 0;
-    s._capacity = 0;
-    memset(s._char_buffer, 0, CHAR_BUFFER_SIZE);
-    s._flags.reset();
-    return *this;
+  if (_size > SMALL_STRING_MAX_LENGTH) {
+    _data = s._data;
+  } else {
+    pointToInSituMemory();
+  }
+  
+  s._data     = nullptr;
+  s._size     = 0;
+  s._capacity = 0;
+  memset(s._char_buffer, 0, CHAR_BUFFER_SIZE);
+  s._flags.reset();
+  return *this;
 }
 
 
-utd::string32::~string32()
-{
-	if (isLargeString())
-	{
-		delete[] _data;
-	}
+utd::string32::~string32() {
+  if (isLargeString()) {
+    delete[] _data;
+  }
 }
 
 // Public Methods
 
-uint64_t utd::string32::size() const
-{
-	return _size;
+uint64_t utd::string32::size() const {
+  return _size;
 }
 
-uint64_t utd::string32::capacity() const
-{
-	if (isLargeString())
-	{
-		return _capacity;
-	}
-	else
-	{
-		return SMALL_STRING_MAX_LENGTH + 1;
-	}
+bool utd::string32::empty() const {
+  return _size == 0;
 }
 
-const char* utd::string32::c_str() const
-{
-    return _data;
+uint64_t utd::string32::capacity() const {
+  if (isLargeString()) {
+    return _capacity;
+  } else {
+    return SMALL_STRING_MAX_LENGTH + 1;
+  }
+}
+
+const char* utd::string32::c_str() const {
+  return _data;
 }
 
 /*
- * Will reserve space for a n-size string. Means that at least n+1 memory space will be allocated to include the null terminator.
+ * Will reserve space for a n-size string. This means that at least n+1 memory space will be allocated to include the null terminator.
  */
-void utd::string32::reserve(uint64_t n)
-{
-	if (n <= SMALL_STRING_MAX_LENGTH) return;
+void utd::string32::reserve(uint64_t n) {
+  if (n <= SMALL_STRING_MAX_LENGTH) {
+    return;
+  }
+  
+  char* new_data = new char[n + 1];
+  
+  if (n < _size) {
+    _size = n;
+  }
+  memcpy(new_data, _data, _size + 1);
+  if (isLargeString()) {
+    delete[] _data;
+  } else {
+    setLargeString();
+  }
 
-	char* new_data = new char[n + 1];
-
-	if (n < _size) _size = n;
-	memcpy(new_data, _data, _size + 1);
-	if (isLargeString()) delete[] _data;
-	_capacity = n + 1;
-
-	_data = new_data;
-	*(_data + _size) = 0;	// regenerate the null terminator
-
-	setLargeString();
+  _capacity        = n + 1;
+  _data            = new_data;
+  *(_data + _size) = 0; // regenerate the null terminator
 }
 
 // Operators
 
-char& utd::string32::operator[](uint64_t index)
-{
-	return _data[index];
+char& utd::string32::operator[](uint64_t index) {
+  return _data[index];
 }
 
 const char& utd::string32::operator[](uint64_t index) const {
-        return _data[index];
+  return _data[index];
 }
 
-utd::string32 utd::string32::operator+(const utd::string32& rhs) const
-{
-	utd::string32 lhs;
-	lhs._size = this->_size + rhs._size;
+utd::string32 utd::string32::operator+(const utd::string32& rhs) const {
+  utd::string32 lhs;
+  lhs._size = this->_size + rhs._size;
 
-	if (lhs._size > SMALL_STRING_MAX_LENGTH) {
-                lhs._capacity = lhs._size + 1;
-                lhs._data     = new char[_capacity];
-                lhs.setLargeString();
-	} else {
-                lhs.pointToInSituMemory();
-	}
-	strcpy(lhs._data, this->_data);
-	strcpy(lhs._data + this->_size, rhs._data);
-	return lhs;
+  if (lhs._size > SMALL_STRING_MAX_LENGTH) {
+    lhs._capacity = lhs._size + 1;
+    lhs._data     = new char[lhs._capacity];
+    lhs.setLargeString();
+  } else {
+    lhs.pointToInSituMemory();
+  }
+  strcpy(lhs._data, this->_data);
+  strcpy(lhs._data + this->_size, rhs._data);
+  return lhs;
 }
 
 utd::string32& utd::string32::operator+=(const utd::string32& rhs) {
-        const uint64_t new_size = _size + rhs._size;
-        if (isLargeString()) {
-                if (new_size >= _capacity) {
-                  _capacity = new_size + 1;
-                  char* new_data = new char[_capacity];
-                  strcpy(new_data, _data);
-                  delete[] _data;
-                  _data = new_data;
-                }
-        } else if (new_size > SMALL_STRING_MAX_LENGTH) {
-                const uint64_t new_capacity = new_size + 1;
-                char*          new_data     = new char[new_capacity];
-                strcpy(new_data, _data);
-                _data     = new_data;
-                _capacity = new_capacity;
-                setLargeString();
-        }
-        strcpy(_data + _size, rhs._data);
-        _size = new_size;
-		return *this;
+  const uint64_t new_size = _size + rhs._size;
+  if (isLargeString()) {
+    if (new_size >= _capacity) {
+      _capacity      = new_size + 1;
+      char* new_data = new char[_capacity];
+      strcpy(new_data, _data);
+      delete[] _data;
+      _data = new_data;
+    }
+  } else if (new_size > SMALL_STRING_MAX_LENGTH) {
+    const uint64_t new_capacity = new_size + 1;
+    char*          new_data     = new char[new_capacity];
+    strcpy(new_data, _data);
+    _data     = new_data;
+    _capacity = new_capacity;
+    setLargeString();
+  }
+  strcpy(_data + _size, rhs._data);
+  _size = new_size;
+  return *this;
 }
 
-utd::string32 utd::string32::operator+(const char& rhs) const
-{
-    utd::string32 lhs;
-    lhs._size = this->_size + 1;
+utd::string32 utd::string32::operator+(char rhs) const {
+  utd::string32 lhs;
+  lhs._size = this->_size + 1;
 
-	if (lhs._size > SMALL_STRING_MAX_LENGTH)
-	{
-                lhs._capacity = lhs._size + 1;
-                lhs._data     = new char[_capacity];
-                lhs.setLargeString();
-	}
-	else
-	{
-                lhs.pointToInSituMemory();
-	}
-	strcpy(lhs._data, this->_data);
-	*(lhs._data + this->_size) = rhs;			// replace null termination with rhs char
-	*(lhs._data + this->_size + 1) = 0;			// add back null termination
-	return lhs;
+  if (lhs._size > SMALL_STRING_MAX_LENGTH) {
+    lhs._capacity = lhs._size + 1;
+    lhs._data     = new char[lhs._capacity];
+    lhs.setLargeString();
+  } else {
+    lhs.pointToInSituMemory();
+  }
+  strcpy(lhs._data, this->_data);
+  *(lhs._data + this->_size) = rhs;   // replace null termination with rhs char
+  *(lhs._data + this->_size + 1) = 0; // add back null termination
+  return lhs;
 }
 
-utd::string32& utd::string32::operator+=(const char& rhs) {
-        _size++;
-        if (isLargeString()) {
-                if (_size == _capacity) {
-                  char* new_data = new char[++_capacity];
-                  strcpy(new_data, _data);
-                  delete[] _data;
-                  _data = new_data;
-                }
-        } else if (_size > SMALL_STRING_MAX_LENGTH) {
-                const uint64_t new_capacity = _size + 1;
-                char*          new_data     = new char[new_capacity];
-                strcpy(new_data, _data);
-                _data     = new_data;
-                _capacity = new_capacity;
-                setLargeString();
-        }
-        *(_data + this->_size) = rhs;			// replace null termination with rhs char
-        *(_data + this->_size + 1) = 0;			// add back null termination
-        return *this;
+utd::string32& utd::string32::operator+=(char rhs) {
+  this->_size++;
+
+  if (isLargeString()) {
+    if (_size == _capacity) {
+      char* new_data = new char[++_capacity];
+      strcpy(new_data, _data);
+      delete[] _data;
+      _data = new_data;
+    }
+  } else if (_size > SMALL_STRING_MAX_LENGTH) {
+    const uint64_t new_capacity = _size + 1;
+    char*          new_data     = new char[new_capacity];
+    strcpy(new_data, _data);
+    _data     = new_data;
+    _capacity = new_capacity;
+    setLargeString();
+  }
+  
+  *(_data + this->_size - 1) = rhs; // replace null termination with rhs char
+  *(_data + this->_size)     = 0;   // add back null termination
+  return *this;
 }
 
-bool utd::operator==(const string32& lhs, const string32& rhs)
-{
-	if (lhs._size != rhs._size) return false;
+bool utd::operator==(const string32& lhs, const char* rhs) {
+  return strcmp(lhs.c_str(), rhs) == 0;
+}
 
-	for (int i = 0; i < lhs._size; i++)
-		if (lhs[i] != rhs[i]) return false;
-
-	return true;
+bool utd::operator==(const string32& lhs, const string32& rhs) {
+  return strcmp(lhs.c_str(), rhs.c_str()) == 0;
 }
 
 // Output Stream
 
 std::ostream& utd::operator<<(std::ostream& os, const utd::string32& s) {
-    os << s._data;
-    return os;
+  os << s._data;
+  return os;
 }

--- a/UTD/src/data-structures/string32.h
+++ b/UTD/src/data-structures/string32.h
@@ -22,7 +22,7 @@ namespace utd {
             bool _unused_flags[7] = { false };
 
 			public:
-            void reset() { memset((void*) this, 0, 1); }
+            void reset() { isLargeString = false; }
           };
 
 
@@ -56,13 +56,15 @@ namespace utd {
 
 		uint64_t size() const;
 
+		bool empty() const;
+
 		uint64_t capacity() const;
 
 		const char* c_str() const;
 
 		void reserve(uint64_t);
 
-		char& operator [](uint64_t);
+		char& operator[](uint64_t);
 
         const char& operator[](uint64_t) const;
 
@@ -70,9 +72,11 @@ namespace utd {
 
 		string32& operator+=(const string32&);
 
-		string32 operator+(const char&) const;
+		string32 operator+(char) const;
 
-		string32& operator+=(const char&);
+		string32& operator+=(char);
+
+		friend bool operator==(const string32&, const char*);
 
 		friend bool operator==(const string32&, const string32&);
 

--- a/UTD/tests/data-structures/string32_test.cpp
+++ b/UTD/tests/data-structures/string32_test.cpp
@@ -17,6 +17,7 @@ static bool isSmallString(const utd::string32& s) {
 TEST(string32, default_constructor) {
   utd::string32 s;
   EXPECT_EQ(s.size(), 0);
+  EXPECT_TRUE(s.empty());
   EXPECT_EQ(s.capacity(), 16);
   EXPECT_TRUE(s == "");
   EXPECT_TRUE(isSmallString(s));
@@ -38,6 +39,7 @@ TEST_P(ConstructorTestFixture, c_str_constructor) {
   auto          params = GetParam();
   utd::string32 s      = params.data;
   EXPECT_EQ(s.size(), params.size);
+  EXPECT_EQ(s.empty(), params.size == 0);
   EXPECT_EQ(s.capacity(), params.capacity);
   EXPECT_TRUE(s == params.data);
   EXPECT_EQ(isSmallString(s), s.size() <= 15);
@@ -48,6 +50,7 @@ TEST_P(ConstructorTestFixture, copy_constructor) {
   utd::string32 s      = params.data;
   utd::string32 s2(s);
   EXPECT_EQ(s2.size(), params.size);
+  EXPECT_EQ(s2.empty(), params.size == 0);
   EXPECT_EQ(s2.capacity(), params.capacity);
   EXPECT_TRUE(s2 == params.data);
   EXPECT_EQ(isSmallString(s2), isSmallString(s));
@@ -58,6 +61,7 @@ TEST_P(ConstructorTestFixture, move_constructor) {
   utd::string32 s      = params.data;
   utd::string32 s2((utd::string32 &&) s);
   EXPECT_EQ(s2.size(), params.size);
+  EXPECT_EQ(s2.empty(), params.size == 0);
   EXPECT_EQ(s2.capacity(), params.capacity);
   EXPECT_TRUE(s2 == params.data);
   EXPECT_EQ(isSmallString(s2), s2.size() <= 15);
@@ -88,11 +92,12 @@ TEST_P(AssignmentTestFixture, copy_assignment) {
   auto          params = GetParam();
   utd::string32 s      = params.data1;
   utd::string32 s2     = params.data2;
-  s                    = s2;
-  EXPECT_EQ(s.size(), s2.size());
-  EXPECT_EQ(s.capacity(), s2.capacity());
-  EXPECT_TRUE(s == s2);
-  EXPECT_EQ(isSmallString(s), isSmallString(s2));
+  s2                    = s;
+  EXPECT_EQ(s2.size(), s.size());
+  EXPECT_EQ(s2.empty(), s.size() == 0);
+  EXPECT_EQ(s2.capacity(), s.capacity());
+  EXPECT_TRUE(s2 == s);
+  EXPECT_EQ(isSmallString(s2), isSmallString(s));
 }
 
 TEST_P(AssignmentTestFixture, move_assignment) {
@@ -104,6 +109,7 @@ TEST_P(AssignmentTestFixture, move_assignment) {
   bool          isSmall  = isSmallString(s);
   s2                    = (utd::string32 &&) s;
   EXPECT_EQ(s2.size(), size);
+  EXPECT_EQ(s2.empty(), size == 0);
   EXPECT_EQ(s2.capacity(), capacity);
   EXPECT_TRUE(s2 == params.data1);
   EXPECT_EQ(isSmallString(s2), isSmall);
@@ -122,3 +128,126 @@ INSTANTIATE_TEST_SUITE_P(
                     AssignmentArgs{ "A heap allocated string.", "12" },
                     AssignmentArgs{ "A heap allocated string.",
                                     "Another heap allocated string." }));
+
+struct ReserveArgs {
+  const char* before;
+  int         reserve;
+  const char* after;
+  int         capacity;
+};
+
+class ReserveTestFixture : public ::testing::TestWithParam<ReserveArgs> {
+protected:
+  ReserveArgs args;
+};
+
+TEST_P(ReserveTestFixture, reserve) {
+  auto          params = GetParam();
+  utd::string32 s      = params.before;
+  s.reserve(params.reserve);
+  EXPECT_TRUE(s == params.after);
+  EXPECT_EQ(s.capacity(), params.capacity);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  string32,
+  ReserveTestFixture,
+  ::testing::Values(
+    ReserveArgs{ "123", 15, "123", 16 },
+    ReserveArgs{ "A heap allocated string.",
+                 15,
+                 "A heap allocated string.",
+                 25 },
+    ReserveArgs{ "123", 20, "123", 21 },
+    ReserveArgs{ "Heap allocated str", 20, "Heap allocated str", 21 },
+    ReserveArgs{ "A heap allocated string.", 20, "A heap allocated str", 21 }));
+
+TEST(string32, sq_bracket_operator) {
+  utd::string32 s = "test";
+  EXPECT_EQ(s[0], 't');
+  EXPECT_EQ(s[2], 's');
+  s[0] = 'T';
+  EXPECT_TRUE(s == "Test");
+}
+
+struct StrConcatArgs {
+  const char* init_str;
+  const char* add_str_1;
+  const char* str_res_1;
+  const char* add_str_2;
+  const char* str_res_2;
+};
+
+class StrConcatTestFixture : public ::testing::TestWithParam<StrConcatArgs> {
+protected:
+  StrConcatArgs args;
+};
+
+TEST_P(StrConcatTestFixture, str_concatentation) {
+  auto          params = GetParam();
+  utd::string32 s      = params.init_str;
+  utd::string32 s2     = s + params.add_str_1;
+  EXPECT_TRUE(s == params.init_str);
+  EXPECT_TRUE(s2 == params.str_res_1);
+  s2 += params.add_str_2;
+  EXPECT_TRUE(s2 == params.str_res_2);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  string32,
+  StrConcatTestFixture,
+  ::testing::Values(StrConcatArgs{ "12", "34", "1234", "56", "123456" },
+                    StrConcatArgs{ "This is ",
+                                   "a heap allocated string",
+                                   "This is a heap allocated string",
+                                   "!!",
+                                   "This is a heap allocated string!!" },
+                    StrConcatArgs{ "This is a heap all",
+                                   "ocated",
+                                   "This is a heap allocated",
+                                   " string because it is long",
+                                   "This is a heap allocated string because it is long" },
+                    StrConcatArgs{ "This is a heap all",
+                                   "ocated string",
+                                   "This is a heap allocated string",
+                                   "",
+                                    "This is a heap allocated string" }));
+
+struct CharConcatArgs {
+  const char* init_str;
+  char        add_char_1;
+  const char* str_res_1;
+  char        add_char_2;
+  const char* str_res_2;
+};
+
+class CharConcatTestFixture : public ::testing::TestWithParam<CharConcatArgs> {
+protected:
+  CharConcatArgs args;
+};
+
+TEST_P(CharConcatTestFixture, char_concatentation) {
+  auto          params = GetParam();
+  utd::string32 s      = params.init_str;
+  utd::string32 s2     = s + params.add_char_1;
+  EXPECT_TRUE(s == params.init_str);
+  EXPECT_TRUE(s2 == params.str_res_1);
+  s2 += params.add_char_2;
+  EXPECT_TRUE(s2 == params.str_res_2);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  string32,
+  CharConcatTestFixture,
+  ::testing::Values(CharConcatArgs{ "12", '3', "123", '4', "1234" },
+                    CharConcatArgs{ "A small string.", '.', "A small string..", '?', "A small string..?" },
+                    CharConcatArgs{ "A small string",
+                                    '.',
+                                    "A small string.",
+                                    '?',
+                                    "A small string.?" },
+                    CharConcatArgs{ "A heap allocated string",
+                                    '?',
+                                    "A heap allocated string?",
+                                    '!',
+                                    "A heap allocated string?!" }));


### PR DESCRIPTION
- Fix code style formatting of string32.cpp
- Add `empty()` fun
- Add `==` operator to compare directly with c str instead of requiring implicit conversion
- Add rest of string32 UT
- Fixed some bugs while testing with UT