### PR TITLE
Fix unordered_set reserve

### DIFF
--- a/UTD/src/data-structures/string.h
+++ b/UTD/src/data-structures/string.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstring> // should this be removed?
 #include <iostream>
 

--- a/UTD/src/data-structures/unordered_set.h
+++ b/UTD/src/data-structures/unordered_set.h
@@ -3,6 +3,7 @@
 #include "../utils/hash.h"
 #include <cstring>  // need this for memcpy
 #include <iostream> // Remove after testing
+#include <cmath>   // TODO: remove this
 
 namespace utd {
   template <typename T>
@@ -18,7 +19,8 @@ namespace utd {
    * initialisation and helper function to delete all pointers in the list
    */
   template <typename T>
-  struct linked_list {
+  struct linked_list { // TODO: can this be reused for map? If so, what should
+                       // we name it?
     typedef node<T>* node_ptr;
 
     node_ptr head;
@@ -36,26 +38,74 @@ namespace utd {
   };
 
   template <typename T>
-  class set {
+  class unordered_set {
   private:
     typedef node<T>*        node_ptr;
     static constexpr size_t DEFAULT_BUCKET_COUNT{ 10 };
+    static constexpr int    EXPAND_SIZE_MULTIPLIER{ 2 };
+    static constexpr float  DEFAULT_MAX_LOAD_FACTOR{ 1.0 };
 
     size_t _num_elements; // number of elements stored in the set currently
     size_t _bucket_count; // size of _buckets
     linked_list<T>* _buckets;
+
+    /*
+     * Load factor is the _num_elements / _bucket_count. Max load factor is the
+     * maximum value of load factor before resizing has to happen
+     */
+    float _max_load_factor = DEFAULT_MAX_LOAD_FACTOR;
+
+    size_t getRequiredBucketCount(size_t size) const {
+      // TODO: remove use of std::ceil
+      const float req_buckets_float = ceil(size * _max_load_factor);
+      return static_cast<size_t>(req_buckets_float);
+    }
 
     void insertElement(node_ptr& bucket_node_ref, const T& item) {
       bucket_node_ref = new node(item);
       _num_elements++;
     }
 
+    void changeBucketCount(size_t new_bucket_count) {
+      linked_list<T>* new_buckets = new linked_list<T>[new_bucket_count]();
+
+      // moving data from old buckets to new buckets, can't use memcpy because
+      // rehashing is needed
+      for (int i = 0; i < _bucket_count; i++) {
+        node_ptr* curr_ptr_addr = &(_buckets[i].head);
+
+        // iterate over every node in old bucket
+        while (*curr_ptr_addr) {
+          const size_t hashed_index     = utd::hash<T>((*curr_ptr_addr)->value);
+          const size_t new_bucket_index = hashed_index % new_bucket_count;
+
+          // get last pointer address of new bucket
+          node_ptr* last_ptr_addr = &(new_buckets[new_bucket_index].head);
+          while (*last_ptr_addr)
+            last_ptr_addr = &((*last_ptr_addr)->next);
+
+          // point last pointer of new bucket to existing node in old bucket
+          *last_ptr_addr = *curr_ptr_addr;
+
+          // iterate to next node in old bucket
+          curr_ptr_addr = &((*curr_ptr_addr)->next);
+
+          // last node in new bucket should not point to anything
+          (*last_ptr_addr)->next = nullptr;
+        }
+      }
+
+      delete[] _buckets;
+      _buckets      = new_buckets;
+      _bucket_count = new_bucket_count;
+    }
+
   public:
-    set() : _num_elements(0), _bucket_count(DEFAULT_BUCKET_COUNT) {
+    unordered_set() : _num_elements(0), _bucket_count(DEFAULT_BUCKET_COUNT) {
       _buckets = new linked_list<T>[DEFAULT_BUCKET_COUNT]();
     }
 
-    ~set() {
+    ~unordered_set() {
       for (int i = 0; i < _bucket_count; i++)
         _buckets[i].clear();
       delete[] _buckets;
@@ -63,46 +113,51 @@ namespace utd {
 
     // TODO: add copy assignment and move assignment + constructor
 
-    void reserve(size_t new_size) {
-      _bucket_count = new_size;
+    // TODO: in cpp standard this returns size_type (usually a typedef for
+    // size_t, but should look into this)
+    size_t bucket_count() const noexcept { return _bucket_count; }
 
-      linked_list<T>* _new_buckets = new linked_list<T>[_bucket_count]();
-      memcpy(_new_buckets, _buckets, sizeof(linked_list<T>) * _bucket_count);
-      delete[] _buckets;
-      _buckets = _new_buckets;
+    float max_load_factor() const noexcept { return _max_load_factor; }
+
+    void max_load_factor(float load_factor) { _max_load_factor = load_factor; }
+
+    /*
+     * Does nothing if new load factor is smaller than max load factor
+     */
+    void reserve(size_t size) {
+      const size_t req_buckets = getRequiredBucketCount(size);
+      if (req_buckets > _bucket_count)
+        changeBucketCount(req_buckets);
     }
 
     /*
      * Creates a copy of the item and inserts it into the set
      */
     void insert(T item) { // TODO: should return pair<iterator,bool>
-      if (_num_elements == _bucket_count) {
-        reserve(_bucket_count * 2);
-      }
+      const size_t req_buckets = getRequiredBucketCount(_num_elements + 1);
+      if (req_buckets > _bucket_count)
+        changeBucketCount(_bucket_count * EXPAND_SIZE_MULTIPLIER);
 
       const size_t    hashed_index = utd::hash<T>(item);
       const size_t    bucket_index = hashed_index % _bucket_count;
       linked_list<T>& bucket       = _buckets[bucket_index];
 
-      // TODO: any way to improve below code to reduce branching?
-      if (!bucket.head) {
-        insertElement(bucket.head, item);
-      } else {
-        node_ptr curr_ptr = bucket.head;
-        while (true) {
-          if (curr_ptr->value == item) {
-            // item already exists, don't do anything
-            return;
-          } else if (curr_ptr->next) {
-            // iterate to next node
-            curr_ptr = curr_ptr->next;
-          } else {
-            // reached end of the list
-            insertElement(curr_ptr->next, item);
-            return;
-          }
-        }
+      node_ptr* curr_ptr_addr = &(bucket.head);
+      while (*curr_ptr_addr) {
+        if ((*curr_ptr_addr)->value == item)
+          return;
+        curr_ptr_addr = &((*curr_ptr_addr)->next);
       }
+      insertElement(*curr_ptr_addr, item);
+
+      /* Broken Example */
+      // node_ptr curr_ptr = bucket.head;  -> broken here because copy assigning
+      // new dangling pointer while (curr_ptr) {
+      //   if (curr_ptr->value == item)
+      //     return;
+      //   curr_ptr = curr_ptr->next;
+      // }
+      // insertElement(curr_ptr, item);
     }
 
     // TODO: add move insert overload

--- a/UTD/src/demo/demo.cpp
+++ b/UTD/src/demo/demo.cpp
@@ -4,55 +4,70 @@
 
 #include "../data-structures/array.h"
 #include "../data-structures/string32.h"
-#include "../utils/timer.h"
 #include "../data-structures/unordered_set.h"
+#include "../utils/timer.h"
 
 static constexpr char LINE_BRK{ '\n' };
 
 static void run_array() {
-    utd::array<int, 2> a;
+  utd::array<int, 2> a;
 
-    for (int i = 0; i < 10000; i++) {
-        a[0] = 0;
-        a[1] = 1;
-    }
+  for (int i = 0; i < 10000; i++) {
+    a[0] = 0;
+    a[1] = 1;
+  }
 };
 
 void demo::time_array() {
-    utils::time(run_array);
+  utils::time(run_array);
 }
 
 void demo::demo_string32() {
-    utd::string32 stack_string = "A stack string.";                    // size 15
-    std::cout << stack_string << LINE_BRK;
-    std::cout << " Size=" << stack_string.size() << LINE_BRK;
-    void* cap_addr = (void*)((char*)&stack_string + 16);               // sizeof(_data) = 8, sizeof(_size) = 8
-    std::cout << "capacity address=" << cap_addr
-              << ", data address=" << (void *)stack_string.c_str() << LINE_BRK;
+  utd::string32 stack_string = "A stack string."; // size 15
+  std::cout << stack_string << LINE_BRK;
+  std::cout << " Size=" << stack_string.size() << LINE_BRK;
+  void* cap_addr = (void*) ((char*) &stack_string +
+                            16); // sizeof(_data) = 8, sizeof(_size) = 8
+  std::cout << "capacity address=" << cap_addr
+            << ", data address=" << (void*) stack_string.c_str() << LINE_BRK;
 
-    utd::string32 heap_string = "A heap allocated string.";           // size 24
-    std::cout << heap_string << LINE_BRK;
-    std::cout << " Size=" << heap_string.size() << LINE_BRK;
-    cap_addr = (void*)((char*)&heap_string + 16);
-    std::cout << "capacity address=" << cap_addr
-        << ", data address=" << (void*)heap_string.c_str() << LINE_BRK;
+  utd::string32 heap_string = "A heap allocated string."; // size 24
+  std::cout << heap_string << LINE_BRK;
+  std::cout << " Size=" << heap_string.size() << LINE_BRK;
+  cap_addr = (void*) ((char*) &heap_string + 16);
+  std::cout << "capacity address=" << cap_addr
+            << ", data address=" << (void*) heap_string.c_str() << LINE_BRK;
 
-    std::cout << "stack string capacity before reserve   = " << stack_string.capacity() << LINE_BRK;
-    stack_string.reserve(49);
-    std::cout << "stack string capacity after reserve 49 = " << stack_string.capacity() << LINE_BRK;
+  std::cout << "stack string capacity before reserve   = "
+            << stack_string.capacity() << LINE_BRK;
+  stack_string.reserve(49);
+  std::cout << "stack string capacity after reserve 49 = "
+            << stack_string.capacity() << LINE_BRK;
 
-    std::cout << "heap string capacity before reserve    = " << heap_string.capacity() << LINE_BRK;
-    heap_string.reserve(15);
-    std::cout << "heap string capacity after reserve 15  = " << heap_string.capacity() << LINE_BRK;
-    heap_string.reserve(49);
-    std::cout << "heap string capacity after reserve 49  = " << heap_string.capacity() << LINE_BRK;
+  std::cout << "heap string capacity before reserve    = "
+            << heap_string.capacity() << LINE_BRK;
+  heap_string.reserve(15);
+  std::cout << "heap string capacity after reserve 15  = "
+            << heap_string.capacity() << LINE_BRK;
+  heap_string.reserve(49);
+  std::cout << "heap string capacity after reserve 49  = "
+            << heap_string.capacity() << LINE_BRK;
 }
 
 void demo::demo_set() {
-    utd::set<int> s;
-    s.insert(3);
-    s.insert(3);
-    s.insert(2147483647);
-    s.insert(-2147483648);
-    s.print_buckets();
+  utd::unordered_set<int> s;
+  s.insert(3);
+  s.insert(3);
+  s.insert(2147483647);
+  s.insert(-2147483648);
+  s.print_buckets();
+  std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;
+
+  s.reserve(14);
+  s.print_buckets();
+  std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;
+
+  s.reserve(5);
+  s.print_buckets();
+  std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;
 }

--- a/UTD/src/utils/hash.cpp
+++ b/UTD/src/utils/hash.cpp
@@ -2,6 +2,6 @@
 
 template <>
 size_t utd::hash<int>(const int& obj) {
-  // works because sizeof int is always smaller than size_t
+  // works because sizeof(int) <= sizeof(size_t)
   return static_cast<size_t>(obj);
 }


### PR DESCRIPTION
- Reserve was broken because of 2 reasons:
  - Undefined behaviour/memory leak when new_size was smaller than current _bucket_count
  - Did not rehash existing elements, which could cause duplicate elements to be put into the set
- Also added:
  - max_load_factor (https://cplusplus.com/reference/unordered_set/unordered_set/max_load_factor/)
  - bucket_count (https://cplusplus.com/reference/unordered_set/unordered_set/bucket_count/)
- TODO:
  - Move implementation into .tpp file
  - Remove use of std::ceil (https://stackoverflow.com/questions/8377412/ceil-function-how-can-we-implement-it-ourselves)