### PR TITLE
Split unordered_set into .h and .tpp files

### DIFF
--- a/UTD/CMakeLists.txt
+++ b/UTD/CMakeLists.txt
@@ -16,6 +16,8 @@ project(
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+##include_directories("${PROJECT_SOURCE_DIR}")
+
 # Libs
 ### Timer
 add_library(timer SHARED)
@@ -32,11 +34,16 @@ add_library(math SHARED)
 set_target_properties(math PROPERTIES CXX_STANDARD 20)
 target_sources(math PRIVATE "src/utils/math.cpp")
 
+### Functional
+add_library(functional SHARED)
+set_target_properties(functional PROPERTIES CXX_STANDARD 20)
+target_sources(functional PRIVATE "src/utils/hash.cpp")
+
 # Build 
 add_executable(main)
 set_property(TARGET main PROPERTY CXX_STANDARD 20)
-target_sources(main PRIVATE "src/demo/demo.cpp" "src/demo/main.cpp" "src/utils/hash.cpp") 
-target_link_libraries(main PRIVATE timer string)
+target_sources(main PRIVATE "src/demo/demo.cpp" "src/demo/main.cpp")
+target_link_libraries(main PRIVATE timer string functional)
 
 # Test
 enable_testing()
@@ -50,7 +57,7 @@ target_sources(main_test PRIVATE
     "tests/data-structures/unordered_set_test.cpp"
     "tests/utils/hash_test.cpp"
 )
-target_link_libraries(main_test gtest_main math string)
+target_link_libraries(main_test gtest_main math string functional)
 
 add_test(NAME main COMMAND main_test)
 
@@ -77,4 +84,8 @@ add_executable(array_test "tests/data-structures/array_test.cpp")
 set_property(TARGET array_test PROPERTY CXX_STANDARD 20)
 target_link_libraries(array_test gtest_main)
 
-gtest_discover_tests(vector_test string32_test array_test)
+add_executable(unordered_set_test "tests/data-structures/unordered_set_test.cpp")
+set_property(TARGET unordered_set_test PROPERTY CXX_STANDARD 20)
+target_link_libraries(unordered_set_test gtest_main functional)
+
+gtest_discover_tests(vector_test string32_test array_test unordered_set_test)

--- a/UTD/src/data-structures/unordered_set.h
+++ b/UTD/src/data-structures/unordered_set.h
@@ -1,17 +1,12 @@
 #pragma once
 
-#include "../utils/hash.h"
-#include <cstring>  // need this for memcpy
-#include <iostream> // Remove after testing
-#include <cmath>   // TODO: remove this
-
 namespace utd {
   template <typename T>
   struct node {
     T        value;
     node<T>* next;
 
-    node(const T& val) : next(nullptr) { memcpy(&value, &val, sizeof(T)); }
+    node(const T&);
   };
 
   /*
@@ -25,25 +20,15 @@ namespace utd {
 
     node_ptr head;
 
-    linked_list() : head(nullptr) {}
+    linked_list();
 
-    void clear() {
-      node_ptr curr_ptr = head;
-      while (curr_ptr) {
-        node_ptr next = curr_ptr->next;
-        delete curr_ptr;
-        curr_ptr = next;
-      }
-    }
+    void clear();
   };
 
   template <typename T>
   class unordered_set {
   private:
-    typedef node<T>*        node_ptr;
-    static constexpr size_t DEFAULT_BUCKET_COUNT{ 10 };
-    static constexpr int    EXPAND_SIZE_MULTIPLIER{ 2 };
-    static constexpr float  DEFAULT_MAX_LOAD_FACTOR{ 1.0 };
+    typedef node<T>* node_ptr;
 
     size_t _num_elements; // number of elements stored in the set currently
     size_t _bucket_count; // size of _buckets
@@ -53,126 +38,46 @@ namespace utd {
      * Load factor is the _num_elements / _bucket_count. Max load factor is the
      * maximum value of load factor before resizing has to happen
      */
-    float _max_load_factor = DEFAULT_MAX_LOAD_FACTOR;
+    float _max_load_factor;
 
-    size_t getRequiredBucketCount(size_t size) const {
-      // TODO: remove use of std::ceil
-      const float req_buckets_float = ceil(size * _max_load_factor);
-      return static_cast<size_t>(req_buckets_float);
-    }
+    size_t getRequiredBucketCount(size_t) const;
 
-    void insertElement(node_ptr& bucket_node_ref, const T& item) {
-      bucket_node_ref = new node(item);
-      _num_elements++;
-    }
+    void insertElement(node_ptr&, const T&);
 
-    void changeBucketCount(size_t new_bucket_count) {
-      linked_list<T>* new_buckets = new linked_list<T>[new_bucket_count]();
-
-      // moving data from old buckets to new buckets, can't use memcpy because
-      // rehashing is needed
-      for (int i = 0; i < _bucket_count; i++) {
-        node_ptr* curr_ptr_addr = &(_buckets[i].head);
-
-        // iterate over every node in old bucket
-        while (*curr_ptr_addr) {
-          const size_t hashed_index     = utd::hash<T>((*curr_ptr_addr)->value);
-          const size_t new_bucket_index = hashed_index % new_bucket_count;
-
-          // get last pointer address of new bucket
-          node_ptr* last_ptr_addr = &(new_buckets[new_bucket_index].head);
-          while (*last_ptr_addr)
-            last_ptr_addr = &((*last_ptr_addr)->next);
-
-          // point last pointer of new bucket to existing node in old bucket
-          *last_ptr_addr = *curr_ptr_addr;
-
-          // iterate to next node in old bucket
-          curr_ptr_addr = &((*curr_ptr_addr)->next);
-
-          // last node in new bucket should not point to anything
-          (*last_ptr_addr)->next = nullptr;
-        }
-      }
-
-      delete[] _buckets;
-      _buckets      = new_buckets;
-      _bucket_count = new_bucket_count;
-    }
+    void changeBucketCount(size_t);
 
   public:
-    unordered_set() : _num_elements(0), _bucket_count(DEFAULT_BUCKET_COUNT) {
-      _buckets = new linked_list<T>[DEFAULT_BUCKET_COUNT]();
-    }
+    unordered_set();
 
-    ~unordered_set() {
-      for (int i = 0; i < _bucket_count; i++)
-        _buckets[i].clear();
-      delete[] _buckets;
-    }
+    ~unordered_set();
 
     // TODO: add copy assignment and move assignment + constructor
 
+    size_t size() const noexcept;
+
     // TODO: in cpp standard this returns size_type (usually a typedef for
     // size_t, but should look into this)
-    size_t bucket_count() const noexcept { return _bucket_count; }
+    size_t bucket_count() const noexcept;
 
-    float max_load_factor() const noexcept { return _max_load_factor; }
+    float max_load_factor() const noexcept;
 
-    void max_load_factor(float load_factor) { _max_load_factor = load_factor; }
+    void max_load_factor(float load_factor);
 
     /*
      * Does nothing if new load factor is smaller than max load factor
      */
-    void reserve(size_t size) {
-      const size_t req_buckets = getRequiredBucketCount(size);
-      if (req_buckets > _bucket_count)
-        changeBucketCount(req_buckets);
-    }
+    void reserve(size_t);
 
     /*
      * Creates a copy of the item and inserts it into the set
      */
-    void insert(T item) { // TODO: should return pair<iterator,bool>
-      const size_t req_buckets = getRequiredBucketCount(_num_elements + 1);
-      if (req_buckets > _bucket_count)
-        changeBucketCount(_bucket_count * EXPAND_SIZE_MULTIPLIER);
-
-      const size_t    hashed_index = utd::hash<T>(item);
-      const size_t    bucket_index = hashed_index % _bucket_count;
-      linked_list<T>& bucket       = _buckets[bucket_index];
-
-      node_ptr* curr_ptr_addr = &(bucket.head);
-      while (*curr_ptr_addr) {
-        if ((*curr_ptr_addr)->value == item)
-          return;
-        curr_ptr_addr = &((*curr_ptr_addr)->next);
-      }
-      insertElement(*curr_ptr_addr, item);
-
-      /* Broken Example */
-      // node_ptr curr_ptr = bucket.head;  -> broken here because copy assigning
-      // new dangling pointer while (curr_ptr) {
-      //   if (curr_ptr->value == item)
-      //     return;
-      //   curr_ptr = curr_ptr->next;
-      // }
-      // insertElement(curr_ptr, item);
-    }
+    void insert(T);
 
     // TODO: add move insert overload
 
     // Test function - remove when done
-    void print_buckets() {
-      std::cout << '[';
-      for (int i = 0; i < _bucket_count; i++) {
-        node<T>* curr = _buckets[i].head;
-        while (curr) {
-          std::cout << curr->value << ',';
-          curr = curr->next;
-        }
-      }
-      std::cout << ']' << '\n';
-    }
+    void print_buckets();
   };
 } // namespace utd
+
+#include "unordered_set.tpp"

--- a/UTD/src/data-structures/unordered_set.tpp
+++ b/UTD/src/data-structures/unordered_set.tpp
@@ -1,0 +1,162 @@
+#include "../utils/hash.h"
+#include <cmath>    // TODO: remove this
+#include <cstring>  // need this for memcpy
+#include <iostream> // Remove after testing
+
+constexpr size_t DEFAULT_BUCKET_COUNT{ 1 };
+constexpr int    EXPAND_SIZE_MULTIPLIER{ 2 };
+constexpr float  DEFAULT_MAX_LOAD_FACTOR{ 1.0 };
+
+template <typename T>
+utd::node<T>::node(const T& val) : next(nullptr) {
+  memcpy(&value, &val, sizeof(T));
+}
+
+template <typename T>
+utd::linked_list<T>::linked_list() : head(nullptr) {}
+
+template <typename T>
+void utd::linked_list<T>::clear() {
+  node_ptr curr_ptr = head;
+  while (curr_ptr) {
+    node_ptr next = curr_ptr->next;
+    delete curr_ptr;
+    curr_ptr = next;
+  }
+}
+
+template <typename T>
+utd::unordered_set<T>::unordered_set()
+    : _num_elements(0)
+    , _bucket_count(DEFAULT_BUCKET_COUNT)
+    , _max_load_factor(DEFAULT_MAX_LOAD_FACTOR) {
+  _buckets = new linked_list<T>[DEFAULT_BUCKET_COUNT]();
+}
+
+template <typename T>
+utd::unordered_set<T>::~unordered_set() {
+  for (int i = 0; i < _bucket_count; i++)
+    _buckets[i].clear();
+  delete[] _buckets;
+}
+
+// TODO: this can be a util method
+template <typename T>
+size_t utd::unordered_set<T>::getRequiredBucketCount(size_t size) const {
+  // TODO: remove use of std::ceil
+  const float req_buckets_float = ceil(size * _max_load_factor);
+  return static_cast<size_t>(req_buckets_float);
+}
+
+template <typename T>
+void utd::unordered_set<T>::insertElement(node_ptr& bucket_node_ref,
+                                          const T&  item) {
+  bucket_node_ref = new node(item);
+  _num_elements++;
+
+  // check if rehash is needed
+  const size_t req_buckets = getRequiredBucketCount(_num_elements);
+  if (req_buckets > _bucket_count)
+    // TODO: more efficient size increase?
+    changeBucketCount(_bucket_count * EXPAND_SIZE_MULTIPLIER);
+}
+
+template <typename T>
+void utd::unordered_set<T>::changeBucketCount(size_t new_bucket_count) {
+  linked_list<T>* new_buckets = new linked_list<T>[new_bucket_count]();
+
+  // moving data from old buckets to new buckets, can't use memcpy because
+  // rehashing is needed
+  for (int i = 0; i < _bucket_count; i++) {
+    node_ptr* curr_ptr_addr = &(_buckets[i].head);
+
+    // iterate over every node in old bucket
+    while (*curr_ptr_addr) {
+      const size_t hashed_index     = utd::hash<T>((*curr_ptr_addr)->value);
+      const size_t new_bucket_index = hashed_index % new_bucket_count;
+
+      // get last pointer address of new bucket
+      node_ptr* last_ptr_addr = &(new_buckets[new_bucket_index].head);
+      while (*last_ptr_addr)
+        last_ptr_addr = &((*last_ptr_addr)->next);
+
+      // point last pointer of new bucket to existing node in old bucket
+      *last_ptr_addr = *curr_ptr_addr;
+
+      // iterate to next node in old bucket
+      curr_ptr_addr = &((*curr_ptr_addr)->next);
+
+      // last node in new bucket should not point to anything
+      (*last_ptr_addr)->next = nullptr;
+    }
+  }
+
+  delete[] _buckets;
+  _buckets      = new_buckets;
+  _bucket_count = new_bucket_count;
+}
+
+template <typename T>
+size_t utd::unordered_set<T>::size() const noexcept {
+  return _num_elements;
+}
+
+template <typename T>
+size_t utd::unordered_set<T>::bucket_count() const noexcept {
+  return _bucket_count;
+}
+
+template <typename T>
+float utd::unordered_set<T>::max_load_factor() const noexcept {
+  return _max_load_factor;
+}
+
+template <typename T>
+void utd::unordered_set<T>::max_load_factor(float load_factor) {
+  _max_load_factor = load_factor;
+}
+
+template <typename T>
+void utd::unordered_set<T>::reserve(size_t size) {
+  const size_t req_buckets = getRequiredBucketCount(size);
+  if (req_buckets > _bucket_count)
+    changeBucketCount(req_buckets);
+}
+
+// TODO: should return pair<iterator,bool>
+template <typename T>
+void utd::unordered_set<T>::insert(T item) {
+  const size_t    hashed_index = utd::hash<T>(item);
+  const size_t    bucket_index = hashed_index % _bucket_count;
+  linked_list<T>& bucket       = _buckets[bucket_index];
+
+  node_ptr* curr_ptr_addr = &(bucket.head);
+  while (*curr_ptr_addr) {
+    if ((*curr_ptr_addr)->value == item)
+      return;
+    curr_ptr_addr = &((*curr_ptr_addr)->next);
+  }
+  insertElement(*curr_ptr_addr, item);
+
+  /* Broken Example */
+  // node_ptr curr_ptr = bucket.head;  -> broken here because copy assigning
+  // new dangling pointer while (curr_ptr) {
+  //   if (curr_ptr->value == item)
+  //     return;
+  //   curr_ptr = curr_ptr->next;
+  // }
+  // insertElement(curr_ptr, item);
+}
+
+template <typename T>
+void utd::unordered_set<T>::print_buckets() {
+  std::cout << '[';
+  for (int i = 0; i < _bucket_count; i++) {
+    node<T>* curr = _buckets[i].head;
+    while (curr) {
+      std::cout << curr->value << ',';
+      curr = curr->next;
+    }
+  }
+  std::cout << ']' << '\n';
+}

--- a/UTD/src/demo/demo.cpp
+++ b/UTD/src/demo/demo.cpp
@@ -57,8 +57,17 @@ void demo::demo_string32() {
 void demo::demo_set() {
   utd::unordered_set<int> s;
   s.insert(3);
+  s.print_buckets();
+  std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;
+
   s.insert(3);
+  s.print_buckets();
+  std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;
+
   s.insert(2147483647);
+  s.print_buckets();
+  std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;
+
   s.insert(-2147483648);
   s.print_buckets();
   std::cout << "Bucket count: " << s.bucket_count() << LINE_BRK;

--- a/UTD/src/utils/hash.cpp
+++ b/UTD/src/utils/hash.cpp
@@ -5,3 +5,30 @@ size_t utd::hash<int>(const int& obj) {
   // works because sizeof(int) <= sizeof(size_t)
   return static_cast<size_t>(obj);
 }
+
+template <>
+size_t utd::hash<unsigned int>(const unsigned int& obj) {
+  // works because sizeof(int) <= sizeof(size_t)
+  return static_cast<size_t>(obj);
+}
+
+template <>
+size_t utd::hash<char>(const char& obj) {
+  return static_cast<size_t>(obj);
+}
+
+template <>
+size_t utd::hash<unsigned char>(const unsigned char& obj) {
+  return static_cast<size_t>(obj);
+}
+
+template <>
+size_t utd::hash<bool>(const bool& obj) {
+  return static_cast<size_t>(obj);
+}
+
+template <>
+size_t utd::hash<float>(const float& obj) {
+  // works because sizeof(int) <= sizeof(size_t)
+  return static_cast<size_t>(obj);
+}

--- a/UTD/tests/data-structures/unordered_set_test.cpp
+++ b/UTD/tests/data-structures/unordered_set_test.cpp
@@ -1,1 +1,26 @@
-// TODO: add UT
+#include "gtest/gtest.h"
+
+#include "../../src/data-structures/unordered_set.h"
+
+// TODO: add more once iterator is added
+TEST(unordered_set, basic_tests) {
+  utd::unordered_set<int> s;
+  ASSERT_EQ(s.size(), 0);
+  ASSERT_EQ(s.max_load_factor(), 1.0);
+
+  s.insert(1);
+  ASSERT_EQ(s.size(), 1);
+  ASSERT_EQ(s.bucket_count(), 1);
+
+  s.insert(2);
+  ASSERT_EQ(s.size(), 2);
+  ASSERT_EQ(s.bucket_count(), 2);
+
+  s.insert(1);
+  ASSERT_EQ(s.size(), 2);
+  ASSERT_EQ(s.bucket_count(), 2);
+
+  s.insert(3);
+  ASSERT_EQ(s.size(), 3);
+  ASSERT_EQ(s.bucket_count(), 4);
+}


### PR DESCRIPTION
- Better practice to split declaration and implementation
- Use .tpp file extension for template implementation files
- One logic change to `insert` is to only check if rehashing is needed if item is successfully inserted (if item already exists, does nothing)